### PR TITLE
Add configurable options_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ under `~/.vim`.
 The variable `g:zprint#options_map` will be passed to the `zprint` call as its options map.
 
 ```vim
-;; use the project-specific .zprintrc instead of the global one, if available
+" use the project-specific .zprintrc instead of the global one, if available
 let g:zprint#options_map = '{:search-config? true}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ If you use [Homebrew](https://brew.sh/), you can do it with `brew install bfonta
 
 Clone this repository, then copy the files from `autoload` and `ftplugin` in the same directories
 under `~/.vim`.
+
+### Configuration
+
+The variable `g:zprint#options_map` will be passed to the `zprint` call as its options map.
+
+```vim
+;; use the project-specific .zprintrc instead of the global one, if available
+let g:zprint#options_map = '{:search-config? true}'
+```
+

--- a/autoload/zprint.vim
+++ b/autoload/zprint.vim
@@ -21,8 +21,8 @@ function zprint#apply()
   endif
 
   let current_col = col('.')
-
-  let l:cmd = 'zprint < ' . l:inputfile
+  let l:options_map = get(g:, 'zprint#options_map', '{}')
+  let l:cmd = 'zprint "' . l:options_map . '" < ' . l:inputfile
   let l:out = zprint#System(l:cmd)
   let l:updated_lines = split(l:out, "\n")
 


### PR DESCRIPTION
# The Problem

This plugin doesn't well with a workflow which uses a local .zprintrc file per project (which is sometimes done on a multi-person project where everybody uses the same formatter settings).

# Proposed Solution

Add a `g:zprint#options_map` global variable which is passed to the system zprint call as the options map parameter. Setting this to `'{:search-config? true}'` will cause zprint to use the local config file. You could also use this to set whatever other vim-specific settings you want, although I have a hard time imagining a use-case. 

`g:zprint#options_map` defaults to `'{}'`, which does nothing, so this should be backwards-compatible.